### PR TITLE
Example proxy configuration added

### DIFF
--- a/config/newrelic_plugin.yml.example
+++ b/config/newrelic_plugin.yml.example
@@ -8,6 +8,16 @@ newrelic:
   # All output goes to stdout/stderr.
   #
   verbose: 1
+  #
+  # Update with your proxy information (optional) for 
+  # communicating with new relic servers if you are behind 
+  # a firewall. 
+  # 
+  #proxy:
+  #  address: ''
+  #  port: 
+  #  user: 
+  #  password:
 
 #
 # Agent Configuration, describe your nginx instances here


### PR DESCRIPTION
Could not find good documentation on working with proxy with new relic plugin and had to read their code. Figured I won't be the only person this happens to so added some example configs to your config file.
