### PR TITLE
get path correctly for running the daemon from /etc/init.d

### DIFF
--- a/newrelic_elasticsearch_agent.daemon
+++ b/newrelic_elasticsearch_agent.daemon
@@ -4,5 +4,5 @@ require 'rubygems'
 require 'daemons'
 require 'bundler/setup'
 
-Daemons.run(File.dirname(__FILE__) + '/newrelic_elasticsearch_agent')
+Daemons.run(File.dirname(Pathname.new(__FILE__).realpath) + '/newrelic_elasticsearch_agent')
 


### PR DESCRIPTION
This change is necessary to allow running the daemon script from /etc/init.d (via symlink)
