### PR TITLE
Added support for Http Basic Auth.

### DIFF
--- a/config/newrelic_plugin.yml.example
+++ b/config/newrelic_plugin.yml.example
@@ -30,5 +30,11 @@ agents:
       # Index name
       # using "_all" with provide stats for all indices
       index: "index_name"
+
+      # Username and password for Http Basic Auth
+      # Leave empty if not used
+      username: ""
+      password: ""
+      
       url: "http://localhost:9200"
 

--- a/newrelic_elasticsearch_agent
+++ b/newrelic_elasticsearch_agent
@@ -14,7 +14,7 @@ module ElasticsearchStatsAgent
 
     agent_guid 'com.secondimpression.newrelic-elasticsearch-agent'
     agent_version '0.0.1'
-    agent_config_options :name, :url, :index
+    agent_config_options :name, :url, :index, :username, :password
     agent_human_labels('ElasticSearch') { name }
 
     def setup_metrics
@@ -88,6 +88,11 @@ module ElasticsearchStatsAgent
       begin
         u = URI.parse("#{url}/#{index}/_stats")
         r = ::Net::HTTP::Get.new(u.path)
+
+        if username.to_s != ''
+          r.basic_auth username, password
+        end
+
         http = ::Net::HTTP.new(u.host, u.port)
         http.open_timeout = 5
         http.read_timeout = 5


### PR DESCRIPTION
It's possible to run Elasticsearch with Http Basic Auth, using the ES plugin Jetty. I've updated the newrelic_elasticsearch_agent to support this.

To enable Http Basic Auth, specify a username/password in the configuration file. 
If left empty (or not existing in config file), http auth won't be used (just as today).
